### PR TITLE
[#244] - vision standard deviation

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -217,7 +217,7 @@ public class RobotContainer extends LightningContainer {
 		// new Trigger(coPilot::getLeftBumper).whileTrue(new Index(indexer,() -> -IndexerConstants.INDEXER_DEFAULT_POWER));
 
 		/* Other */
-		// new Trigger(() -> (limelights.getStopMe().hasTarget() || limelights.getChamps().hasTarget())).whileTrue(leds.enableState(LED_STATES.HAS_VISION));
+		new Trigger(() -> (limelights.getStopMe().hasTarget() || limelights.getChamps().hasTarget())).whileTrue(leds.enableState(LED_STATES.HAS_VISION));
 		// new Trigger(() -> collector.hasPiece()).whileTrue(leds.enableState(LED_STATES.HAS_PIECE).withTimeout(2)).onTrue(leds.enableState(LED_STATES.COLLECTED).withTimeout(2));
 
 	}

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -217,7 +217,7 @@ public class RobotContainer extends LightningContainer {
 		// new Trigger(coPilot::getLeftBumper).whileTrue(new Index(indexer,() -> -IndexerConstants.INDEXER_DEFAULT_POWER));
 
 		/* Other */
-		new Trigger(() -> (limelights.getStopMe().hasTarget() || limelights.getChamps().hasTarget())).whileTrue(leds.enableState(LED_STATES.HAS_VISION));
+		// new Trigger(() -> (limelights.getStopMe().hasTarget() || limelights.getChamps().hasTarget())).whileTrue(leds.enableState(LED_STATES.HAS_VISION));
 		// new Trigger(() -> collector.hasPiece()).whileTrue(leds.enableState(LED_STATES.HAS_PIECE).withTimeout(2)).onTrue(leds.enableState(LED_STATES.COLLECTED).withTimeout(2));
 
 	}

--- a/src/main/java/frc/robot/subsystems/Swerve.java
+++ b/src/main/java/frc/robot/subsystems/Swerve.java
@@ -65,7 +65,6 @@ public class Swerve extends SwerveDrivetrain implements Subsystem {
         /* Assume */
         updateSimState(0.02, 12);
     }
-    private final Matrix<N3, N1> m_visionK = VecBuilder.fill(0.5,0.5, Units.degreesToRadians(30));
 
     @Override
     public void periodic() {
@@ -86,7 +85,6 @@ public class Swerve extends SwerveDrivetrain implements Subsystem {
                     confidence = 1.0 + (pose.getDistance()/2 * 5.0);
                 
                 addVisionMeasurement(pose.toPose2d(), pose.getFPGATimestamp(), VecBuilder.fill(confidence, confidence, Math.toRadians(500)));
-                // System.out.println("Vision Updating");
                 LightningShuffleboard.setDouble("Swerve", "Standard Deviation", confidence);
             }
             

--- a/src/main/java/frc/robot/subsystems/Swerve.java
+++ b/src/main/java/frc/robot/subsystems/Swerve.java
@@ -79,12 +79,13 @@ public class Swerve extends SwerveDrivetrain implements Subsystem {
                 // theta trust IMU, use 500 degrees
 
                 double confidence = 18.0;
-                if(pose.getMoreThanOneTarget() && pose.getDistance() < 3)
+                if (pose.getMoreThanOneTarget() && pose.getDistance() < 3){
                     confidence = 0.3;
-                else if (pose.getMoreThanOneTarget())
+                } else if (pose.getMoreThanOneTarget()){
                     confidence = 0.3 + ((pose.getDistance() - 3)/5 * 18);
-                else if (pose.getDistance() < 2)
+                } else if (pose.getDistance() < 2){
                     confidence = 1.0 + (pose.getDistance()/2 * 5.0);
+                }
                 
                 addVisionMeasurement(pose.toPose2d(), pose.getFPGATimestamp(), VecBuilder.fill(confidence, confidence, Math.toRadians(500)));
                 LightningShuffleboard.setDouble("Swerve", "Standard Deviation", confidence);


### PR DESCRIPTION
Added 3 things
1. In shuffleboard, we can see the distance from the limelight to the closest april tag in meters
2. In shuffleboard, we can see if the limelight detects more than 1 april tag
3. Added vision standard deviation(also viewable in shuffleboard). The lower the number, the more trustworthy the data is and vice versa. The number is determined by the distance of the robot to the april tag and by how many april tags we can see.

To see these in shuffleboard, go under "swerve"