### PR TITLE
[#356] - end smart collect for chase pieces

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -447,7 +447,7 @@ public class Constants {
         public static final double BIAS_INCREMENT = 1d; // Degrees to bias by per button press TODO get amount to bias
                                                         // by
 
-        public static final double STOW_ANGLE = 30d;
+        public static final double STOW_ANGLE = 28d;
 
         public static final double MAX_INDEX_ANGLE = 40d;
 

--- a/src/main/java/frc/robot/command/ChasePieces.java
+++ b/src/main/java/frc/robot/command/ChasePieces.java
@@ -88,7 +88,7 @@ public class ChasePieces extends Command {
 		}
 
 		onTarget = Math.abs(targetHeading) < VisionConstants.ALIGNMENT_TOLERANCE;
-		hasPiece = debouncer.calculate(indexer.getExitBeamBreakState());
+		hasPiece = smartCollect.isFinished();
 
 		pidOutput = headingController.calculate(0, targetHeading);
 
@@ -105,12 +105,20 @@ public class ChasePieces extends Command {
 			} else {
 				drivetrain.setRobot(3, 0, 0);
 			}
+		} else {
+			power = 0d;
+			indexer.stop();
+			collector.stop();
+			smartCollect.end(false);
 		}
 
 	}
 
 	@Override
-	public void end(boolean interrupted) {}
+	public void end(boolean interrupted) {
+		power = 0d;
+		smartCollect.end(interrupted);
+	}
 
 	/**
 	 * Makes sure that the robot isn't jerking over to a different side while chasing pieces.

--- a/src/main/java/frc/robot/command/ChasePieces.java
+++ b/src/main/java/frc/robot/command/ChasePieces.java
@@ -31,6 +31,7 @@ public class ChasePieces extends Command {
 
     private boolean onTarget;
 	private boolean hasPiece;
+	private boolean isDone;
 	private boolean hasTarget;
 
 	private Command smartCollect;
@@ -88,7 +89,8 @@ public class ChasePieces extends Command {
 		}
 
 		onTarget = Math.abs(targetHeading) < VisionConstants.ALIGNMENT_TOLERANCE;
-		hasPiece = smartCollect.isFinished();
+		isDone = smartCollect.isFinished();
+		hasPiece = collector.getEntryBeamBreakState();
 
 		pidOutput = headingController.calculate(0, targetHeading);
 
@@ -105,11 +107,6 @@ public class ChasePieces extends Command {
 			} else {
 				drivetrain.setRobot(3, 0, 0);
 			}
-		} else {
-			power = 0d;
-			indexer.stop();
-			collector.stop();
-			smartCollect.end(false);
 		}
 
 	}
@@ -133,6 +130,6 @@ public class ChasePieces extends Command {
 
 	@Override
 	public boolean isFinished() {
-		return hasPiece;
+		return isDone;
 	}
 }

--- a/src/main/java/frc/robot/command/ChasePieces.java
+++ b/src/main/java/frc/robot/command/ChasePieces.java
@@ -71,6 +71,8 @@ public class ChasePieces extends Command {
 	private void initLogging() {
 		LightningShuffleboard.setBoolSupplier("ChasePieces", "On Target", () -> onTarget);
 		LightningShuffleboard.setBoolSupplier("ChasePieces", "Has Target", () -> hasTarget);
+		LightningShuffleboard.setBoolSupplier("ChasePieces", "Is Done", () -> isDone);
+		LightningShuffleboard.setBoolSupplier("ChasePieces", "Has Piece", () -> hasPiece);
 
 		LightningShuffleboard.setDoubleSupplier("ChasePieces", "Target Heading", () -> targetHeading);
 		LightningShuffleboard.setDoubleSupplier("ChasePieces", "Target Y", () -> targetPitch);
@@ -90,14 +92,14 @@ public class ChasePieces extends Command {
 
 		onTarget = Math.abs(targetHeading) < VisionConstants.ALIGNMENT_TOLERANCE;
 		isDone = smartCollect.isFinished();
-		hasPiece = collector.getEntryBeamBreakState();
+		hasPiece = debouncer.calculate(indexer.getEntryBeamBreakState()) || collector.getEntryBeamBreakState();
 
 		pidOutput = headingController.calculate(0, targetHeading);
 
 		if (!hasPiece){
 			if (hasTarget){
 				if (trustValues()){
-					power = 0.75d;
+					power = 0.65d;
 					if (!onTarget) {
 						drivetrain.setRobot(3, 0, -pidOutput);
 					} else {
@@ -107,6 +109,8 @@ public class ChasePieces extends Command {
 			} else {
 				drivetrain.setRobot(3, 0, 0);
 			}
+		} else {
+			drivetrain.setRobot(0, 0, 0);
 		}
 
 	}

--- a/src/main/java/frc/robot/command/SmartCollect.java
+++ b/src/main/java/frc/robot/command/SmartCollect.java
@@ -4,6 +4,7 @@ import java.util.function.DoubleSupplier;
 
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.Constants;
+import frc.robot.Constants.IndexerConstants.PieceState;
 import frc.robot.subsystems.Collector;
 import frc.robot.subsystems.Indexer;
 import frc.robot.subsystems.Pivot;
@@ -93,6 +94,9 @@ public class SmartCollect extends Command {
 
 	@Override
 	public boolean isFinished() {
+		if (reversedFromExit && indexer.getPieceState() == PieceState.IN_PIVOT){
+			return true;
+		}
 		return false;
 	}
 }

--- a/src/main/java/frc/robot/subsystems/Pivot.java
+++ b/src/main/java/frc/robot/subsystems/Pivot.java
@@ -28,7 +28,7 @@ public class Pivot extends SubsystemBase {
     private final PIDController angleController = new PIDController(0.06, 0, 0);
     private double bias = 0;
 
-    private double targetAngle = 30;
+    private double targetAngle = PivotConstants.STOW_ANGLE;
 
     public Pivot() {
         CANcoderConfiguration angleConfig = new CANcoderConfiguration();


### PR DESCRIPTION
Closes #356 

now ends the smart collect properly even if you let go before fully collecting a piece.
make sure you hold the button down the entire time, or else it might not index backwards, making it still in contact w/ flywheel.