### PR TITLE
[#357] fix getpose null issue in simulator

### DIFF
--- a/src/main/java/frc/robot/subsystems/Swerve.java
+++ b/src/main/java/frc/robot/subsystems/Swerve.java
@@ -229,8 +229,9 @@ public class Swerve extends SwerveDrivetrain implements Subsystem {
 
     public Pose2d getPose() {
         var state = getState();
-        if (state == null || getState().Pose == null)
+        if (state == null || getState().Pose == null){
             return new Pose2d();
+        }
 
         return state.Pose;
     }


### PR DESCRIPTION
A few simple fixes for an issue with the simulator when running shuffleboard. Also a minor performance issue.
Closes #357 